### PR TITLE
Change default transport to 'null' which does not require any dependencies after install

### DIFF
--- a/Model/Config/Source/Transport.php
+++ b/Model/Config/Source/Transport.php
@@ -20,6 +20,7 @@ class Transport
             ['value' => 'sqs', 'label' => __('Amazon AWS SQS')],
             ['value' => 'redis', 'label' => __('Redis')],
             ['value' => 'dbal', 'label' => __('Doctrine DBAL')],
+            ['value' => 'null', 'label' => __('Null transport')],
         ];
     }
 }

--- a/Model/EnqueueManager.php
+++ b/Model/EnqueueManager.php
@@ -141,6 +141,9 @@ class EnqueueManager
             case 'dbal':
                 $config['transport'] = $this->getDbalConfig();
                 break;
+            case 'null':
+                $config['transport'] = $this->getNullConfig();
+                break;
             default:
                 throw new \LogicException(sprintf('Unknown transport: "%s"', $name));
         }
@@ -280,5 +283,13 @@ class EnqueueManager
             'polling_interval' => (int) $this->scopeConfig->getValue('enqueue/dbal/polling_interval'),
             'lazy' => (bool) $this->scopeConfig->getValue('enqueue/dbal/lazy'),
         ]];
+    }
+
+    /**
+     * @return array
+     */
+    private function getNullConfig(): array
+    {
+        return ['null' => []];
     }
 }

--- a/Plugin/Model/Config/ConfigPlugin.php
+++ b/Plugin/Model/Config/ConfigPlugin.php
@@ -3,6 +3,7 @@
 namespace Enqueue\Magento2\Plugin\Model\Config;
 
 use \Enqueue\AmqpExt\AmqpContext;
+use Enqueue\Null\NullContext;
 use \Enqueue\Stomp\StompContext;
 use \Enqueue\Fs\FsContext;
 use \Enqueue\Sqs\SqsContext;
@@ -55,6 +56,11 @@ class ConfigPlugin
             'name' => 'Doctrine DBAL',
             'package' => 'enqueue/dbal',
             'class' => DbalContext::class,
+        ],
+        'null' => [
+            'name' => 'Null transport',
+            'package' => 'enqueue/null',
+            'class' => NullContext::class
         ]
     ];
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
     <default>
         <enqueue>
             <transport>
-                <default>rabbitmq_amqp</default>
+                <default>null</default>
             </transport>
             <client>
                 <prefix>enqueue</prefix>


### PR DESCRIPTION
Right after installation, any console command shows an exception (not only enqueue's, just `php bin/magento` would be enough):

> Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
>
> Invalid configuration for path "enqueue.transport.rabbitmq_amqp": In order to use the transport "rabbitmq_amqp" install one of the packages "enqueue/amqp-ext", "enqueue/amqp-bunny", "enqueue/amqp-lib"

It's incorrect behavior after module installation, especially in case you didn't want to use AMQP at all.
That's why I'm adding a null transport which could be declared without any dependencies and could be switched to a real one when its configuration would be provided and dependencies are installed.