### PR TITLE
Rename plugin to follow best practices

### DIFF
--- a/Plugin/Config/ValidateConfiguration.php
+++ b/Plugin/Config/ValidateConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enqueue\Magento2\Plugin\Model\Config;
+namespace Enqueue\Magento2\Plugin\Config;
 
 use \Enqueue\AmqpExt\AmqpContext;
 use Enqueue\Null\NullContext;
@@ -11,7 +11,7 @@ use \Enqueue\Redis\RedisContext;
 use \Enqueue\Dbal\DbalContext;
 use \Magento\Framework\Exception\TemporaryState\CouldNotSaveException;
 
-class ConfigPlugin
+class ValidateConfiguration
 {
     /**
      * @var array
@@ -75,21 +75,19 @@ class ConfigPlugin
         if (isset($beforeSaveData['transport']['fields']['default']['value'])) {
             $configValue = $beforeSaveData['transport']['fields']['default']['value'];
 
-            if (false == isset($this->_preDefinedServices[$configValue])) {
+            if (false === isset($this->_preDefinedServices[$configValue])) {
                 throw new \LogicException(sprintf('Unknown transport: "%s"', $configValue));
             }
 
-            if (false == $this->isClassExists($this->_preDefinedServices[$configValue]['class'])) {
+            if (false === $this->isClassExists($this->_preDefinedServices[$configValue]['class'])) {
                 throw new CouldNotSaveException(
                     __(
-                        vsprintf(
-                        '%s transport requires package "%s". Please install it via composer. #> php composer.php require %s',
+                        '%name transport requires package "%package".'
+                        . ' Please install it via composer. #> php composer.php require %package',
                         [
-                            $this->_preDefinedServices[$configValue]['name'],
-                            $this->_preDefinedServices[$configValue]['package'],
-                            $this->_preDefinedServices[$configValue]['package']
+                            'name' => $this->_preDefinedServices[$configValue]['name'],
+                            'package' => $this->_preDefinedServices[$configValue]['package'],
                         ]
-                    )
                     )
                 );
             }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -6,6 +6,6 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="\Magento\Config\Model\Config">
-        <plugin name="config_data_plugin" type="Enqueue\Magento2\Plugin\Model\Config\ConfigPlugin"/>
+        <plugin name="enqueue_config_validation" type="Enqueue\Magento2\Plugin\Config\ValidateConfiguration"/>
     </type>
 </config>


### PR DESCRIPTION
Renames a plugin according to best practices:
- It's name in declaration should be unique as a name is the key which could be used to replace/disable plugin 
- Plugin name should show its purpose, not which class it covers