### PR TITLE
Add support for enqueue 0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "keywords": ["messaging", "queue", "amqp", "magento", "magento2", "rabbitmq", "kafka", "redis", "sqs", "google-pubsub", "amazon-sqs", "gearman", "beanstalk", "amqp"],
   "require": {
-    "enqueue/enqueue": "^0.8",
-    "enqueue/simple-client": "^0.8"
+    "enqueue/enqueue": "^0.10",
+    "enqueue/simple-client": "^0.10"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
Per https://github.com/php-enqueue/enqueue-dev/issues/1321#issuecomment-1798527799 (cc @makasim)

I’m not sure how to test this. The [contribution guide in enqueue-dev](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/contribution.md) mention commands that don’t exist in this repo (and it’s not listed as a [split repo](https://github.com/php-enqueue/enqueue-dev/blob/master/bin/subtree-split#L46)).